### PR TITLE
arize v8.33.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "arize" %}
-{% set version = "7.52.0" %}
+{% set version = "8.33.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/arize-{{ version }}.tar.gz
-  sha256: 485a7bef2190fb34b67cd2959077ea358b1e0a29da66c4ddddc791ccda33950d
+  sha256: dfac8635164fc2707aaf1c42b4c637a8967a5fc6d683f233f83d7aaf602cf5c4
 
 build:
-  number: 1
+  number: 0
   noarch: python
 
 requirements:
@@ -34,20 +34,30 @@ outputs:
         - pip
       run:
         - python >={{ python_min }}
-        - requests-futures ==1.0.0
-        - googleapis-common-protos >=1.51.0,<2
+        - numpy >=2.0.0
+        - openinference-semantic-conventions >=0.1.25,<1
+        - opentelemetry-exporter-otlp-proto-common >=1.38.0
+        - opentelemetry-exporter-otlp-proto-grpc >=1.38.0
+        - opentelemetry-sdk >=1.38.0
+        - opentelemetry-semantic-conventions >=0.43b0,<1
+        - pandas >=2.0.0,<3
         - protobuf >=4.21.0,<7
-        - pandas >=0.25.3,<3
         - pyarrow >=0.15.0
-        - tqdm >=4.60.0,<5
-        - pydantic >=2.0.0,<3
+        - pydantic >=2,<3
+        - python-dateutil >=2.8.2,<3
+        - requests >=2.0.0,<3
+        - requests-futures >=1.0.0,<2
+        - tqdm >4,<5
+        - typing-extensions >=4.7.1,<5
+        - urllib3 >=2.1.0,<3
+        - wrapt >=1.0.0,<2.0.0
     test:
       imports:
         - arize
       requires:
         - python {{ python_min }}
 
-  - name: {{ name|lower }}-with-autoembeddings
+  - name: {{ name|lower }}-with-embeddings
     build:
       number: 0
       noarch: python
@@ -57,19 +67,19 @@ outputs:
       run:
         - python >={{ python_min }}
         - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
-        - transformers >=4.25,<5
-        - tokenizers >=0.13,<1
-        - datasets >=2.8,<3,!=2.14.*
-        - pytorch >=1.13,<3
         - pillow >=8.4.0,<11
+        - datasets >=2.8,<3,!=2.14.*
+        - tokenizers >=0.13,<1
+        - pytorch >=1.13,<3
+        - transformers >=4.25,<5
     test:
       imports:
         - arize
-        - arize.pandas.embeddings
+        - arize.embeddings
       requires:
         - python {{ python_min }}
 
-  - name: {{ name|lower }}-with-nlp-metrics
+  - name: {{ name|lower }}-with-mimic
     build:
       number: 0
       noarch: python
@@ -79,105 +89,28 @@ outputs:
       run:
         - python >={{ python_min }}
         - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
-        - nltk >=3.0.0,<4
-        - sacrebleu >=2.3.1,<3
-        - rouge-score >=0.1.2,<1
-        - evaluate >=0.3,<1
-        - datasets !=2.14.*
+        - interpret-community >=0.22.0,<1
+        - lightgbm
     test:
       imports:
         - arize
-        - arize.pandas.generative.nlp_metrics
-        - arize.pandas.generative.llm_evaluation
-      requires:
-        - python {{ python_min }}
-
-  - name: {{ name|lower }}-with-datasets
-    build:
-      number: 0
-      noarch: python
-    requirements:
-      host:
-        - python {{ python_min }}
-      run:
-        - python >={{ python_min }}
-        - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
-        - typing-extensions >=4,<5
-        - wrapt >=1.12.1,<2
-        - opentelemetry-semantic-conventions >=0.43b0,<1
-        - openinference-semantic-conventions >=0.1.6,<1
-        - opentelemetry-sdk >=1.25.0,<2
-        - opentelemetry-exporter-otlp >=1.25.0,<2
-        - deprecated
-    test:
-      imports:
-        - arize
-      requires:
-        - python {{ python_min }}
-
-  - name: {{ name|lower }}-with-tracing
-    build:
-      number: 0
-      noarch: python
-    requirements:
-      host:
-        - python {{ python_min }}
-      run:
-        - python >={{ python_min }}
-        - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
-        - opentelemetry-semantic-conventions >=0.43b0,<1
-        - openinference-semantic-conventions >=0.1.12,<1
-        - deprecated
-    test:
-      imports:
-        - arize
-      requires:
-        - python {{ python_min }}
-
-  - name: {{ name|lower }}-with-prompthub
-    build:
-      number: 0
-      noarch: python
-    requirements:
-      host:
-        - python {{ python_min }}
-      run:
-        - python >={{ python_min }}
-        - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
-        - gql >=3.0.0,<4.0.0
-        - requests-toolbelt >=1.0.0
-    test:
-      imports:
-        - arize
-      requires:
-        - python {{ python_min }}
-
-  - name: {{ name|lower }}-with-prompthub-vertexai
-    build:
-      number: 0
-      noarch: python
-    requirements:
-      host:
-        - python {{ python_min }}
-      run:
-        - python >={{ python_min }}
-        - {{ pin_subpackage(name|lower, max_pin='x.x.x') }}
-        - google-cloud-aiplatform >=1.0.0
-    test:
-      imports:
-        - arize
+        - arize.ml.surrogate_explainer.mimic
       requires:
         - python {{ python_min }}
 
 about:
-  home: https://github.com/Arize-ai/client_python
+  home: https://arize.com
   summary: A helper library to interact with Arize AI APIs
   dev_url: https://github.com/Arize-ai/client_python
-  license: BSD-3-Clause
-  license_file: LICENSE.md
+  doc_url: https://docs.arize.com/arize
+  license: Apache-2.0
+  license_file:
+    - LICENSE
+    - NOTICE
 
 extra:
   recipe-maintainers:
     - zephyap
     - Shubh18s
+    - fjcasti1
   feedstock-name: {{ name|lower }}


### PR DESCRIPTION
Updates the recipe to **arize 8.33.0**, syncing metadata and dependencies with the upstream [`pyproject.toml`](https://github.com/Arize-ai/client_python/blob/main/pyproject.toml).

Checklist:
- [x] Used a personal fork of the feedstock to propose changes
- [x] Bumped the build number (reset to 0 for the new version)
- [x] Re-rendered with the latest conda-smithy (not needed — no CI/config changes)
- [x] Ensured the license file is being packaged

### Changes
- Bump version `7.52.0` → `8.33.0` and update `sha256`.
- **License**: `BSD-3-Clause` → `Apache-2.0`, packaging `LICENSE` + `NOTICE` (upstream relicensed and added a NOTICE file).
- **Core run deps** restructured to match `pyproject.toml`. The OpenTelemetry / OpenInference stack, `numpy`, `urllib3`, `python-dateutil`, and `requests` now ship in the base package rather than as extras.
- **Extras**: the old `autoembeddings`, `nlp-metrics`, `datasets`, `tracing`, `prompthub`, and `prompthub-vertexai` extras no longer exist upstream. Replaced with the current optional extras:
  - `arize-with-embeddings` (`pillow`, `datasets`, `tokenizers`, `pytorch`, `transformers`)
  - `arize-with-mimic` (`interpret-community` + `lightgbm`)
- The upstream `otel` extra (`arize-otel`) is **deferred**: `arize-otel` is not yet on conda-forge. It will be added as `arize-with-otel` in a follow-up once a dedicated `arize-otel` feedstock exists.
- Added `fjcasti1` as a recipe maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)